### PR TITLE
Add Option to Sort Timers

### DIFF
--- a/lib/timers_list.dart
+++ b/lib/timers_list.dart
@@ -16,6 +16,33 @@ class TimersList extends StatefulWidget {
 }
 
 class _TimersListState extends State<TimersList> {
+  Widget _proxyDecorator(
+    Widget child,
+    int index,
+    Animation<double> animation,
+  ) {
+    return Material(
+      elevation: 0,
+      color: Colors.transparent,
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 16,
+            child: Material(
+              borderRadius: BorderRadius.circular(4),
+              elevation: 24,
+              color: Colors.transparent,
+            ),
+          ),
+          child,
+        ],
+      ),
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -63,122 +90,154 @@ class _TimersListState extends State<TimersList> {
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: SingleChildScrollView(
-            child: ListView.separated(
+            child: ReorderableListView.builder(
               shrinkWrap: true,
+              buildDefaultDragHandles: false,
               physics: const NeverScrollableScrollPhysics(),
-              itemCount: timers.timers.length,
-              separatorBuilder: (context, index) {
-                return const SizedBox(height: 16);
+              onReorder: (int start, int current) {
+                timers.reorder(start, current);
               },
+              proxyDecorator: (
+                Widget child,
+                int index,
+                Animation<double> animation,
+              ) {
+                return _proxyDecorator(child, index, animation);
+              },
+              itemCount: timers.timers.length,
               itemBuilder: (context, index) {
-                return Stack(
-                  clipBehavior: Clip.antiAlias,
-                  children: [
-                    Positioned.fill(
-                      child: Builder(
-                        builder: (context) => Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 8),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Colors.blue[900]!,
-                              borderRadius:
-                                  const BorderRadius.all(Radius.circular(4.0)),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Slidable(
-                      key: UniqueKey(),
-                      endActionPane: ActionPane(
-                        motion: const DrawerMotion(),
-                        extentRatio: 0.3 * 2,
-                        children: [
-                          SlidableAction(
-                            onPressed: (context) {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute<void>(
-                                  builder: (BuildContext context) {
-                                    return TimersAdd(
-                                      existingTimerIndex: index,
-                                      existingTimer: timers.timers[index],
-                                    );
-                                  },
+                return Padding(
+                  key: ValueKey(timers.timers[index].id),
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Stack(
+                    clipBehavior: Clip.antiAlias,
+                    children: [
+                      Positioned.fill(
+                        child: Builder(
+                          builder: (context) => Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 8),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.blue[900]!,
+                                borderRadius: const BorderRadius.all(
+                                  Radius.circular(4.0),
                                 ),
-                              );
-                            },
-                            backgroundColor: Colors.blue[900]!,
-                            foregroundColor:
-                                Theme.of(context).colorScheme.onPrimary,
-                            icon: Icons.edit,
-                            label: 'Edit',
-                            borderRadius: BorderRadius.zero,
-                          ),
-                          SlidableAction(
-                            onPressed: (context) {
-                              timers.deleteTimer(index);
-                            },
-                            backgroundColor: Colors.red[900]!,
-                            foregroundColor:
-                                Theme.of(context).colorScheme.onPrimary,
-                            icon: Icons.delete,
-                            label: 'Delete',
-                            borderRadius: const BorderRadius.only(
-                              topRight: Radius.circular(4.0),
-                              bottomRight: Radius.circular(4.0),
-                            ),
-                          ),
-                        ],
-                      ),
-                      child: InkWell(
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute<void>(
-                              builder: (BuildContext context) {
-                                return TimersDetails(
-                                  timer: timers.timers[index],
-                                );
-                              },
-                            ),
-                          );
-                        },
-                        child: SizedBox(
-                          width: double.infinity,
-                          child: Card(
-                            color: const Color(0xff1b2738),
-                            margin: EdgeInsets.zero,
-                            child: Padding(
-                              padding: const EdgeInsets.all(16),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    timers.timers[index].name,
-                                    style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onPrimary,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                  ),
-                                  Text(
-                                    '${tr.printDuration(Duration(seconds: timers.timers[index].intervals.map((e) => e.seconds).reduce((a, b) => a + b)))} (${timers.timers[index].intervals.length} ${timers.timers[index].intervals.length == 1 ? 'Interval' : 'Intervals'})',
-                                    style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onPrimary,
-                                    ),
-                                  ),
-                                ],
                               ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                  ],
+                      Slidable(
+                        key: ValueKey(timers.timers[index].id),
+                        endActionPane: ActionPane(
+                          motion: const DrawerMotion(),
+                          extentRatio: 0.3 * 2,
+                          children: [
+                            SlidableAction(
+                              onPressed: (context) {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute<void>(
+                                    builder: (BuildContext context) {
+                                      return TimersAdd(
+                                        existingTimerIndex: index,
+                                        existingTimer: timers.timers[index],
+                                      );
+                                    },
+                                  ),
+                                );
+                              },
+                              backgroundColor: Colors.blue[900]!,
+                              foregroundColor:
+                                  Theme.of(context).colorScheme.onPrimary,
+                              icon: Icons.edit,
+                              label: 'Edit',
+                              borderRadius: BorderRadius.zero,
+                            ),
+                            SlidableAction(
+                              onPressed: (context) {
+                                timers.deleteTimer(index);
+                              },
+                              backgroundColor: Colors.red[900]!,
+                              foregroundColor:
+                                  Theme.of(context).colorScheme.onPrimary,
+                              icon: Icons.delete,
+                              label: 'Delete',
+                              borderRadius: const BorderRadius.only(
+                                topRight: Radius.circular(4.0),
+                                bottomRight: Radius.circular(4.0),
+                              ),
+                            ),
+                          ],
+                        ),
+                        child: InkWell(
+                          onTap: timers.timers[index].intervals.isEmpty
+                              ? null
+                              : () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute<void>(
+                                      builder: (BuildContext context) {
+                                        return TimersDetails(
+                                          timer: timers.timers[index],
+                                        );
+                                      },
+                                    ),
+                                  );
+                                },
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: Card(
+                              color: const Color(0xff1b2738),
+                              margin: EdgeInsets.zero,
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Row(
+                                  children: [
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            timers.timers[index].name,
+                                            style: TextStyle(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onPrimary,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                          Text(
+                                            '${tr.printDuration(Duration(seconds: timers.timers[index].intervals.isEmpty ? 0 : timers.timers[index].intervals.map((e) => e.seconds).reduce((a, b) => a + b)))} (${timers.timers[index].intervals.length} ${timers.timers[index].intervals.length == 1 ? 'Interval' : 'Intervals'})',
+                                            style: TextStyle(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onPrimary,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    ReorderableDragStartListener(
+                                      index: index,
+                                      child: Icon(
+                                        Icons.drag_handle,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onPrimary,
+                                        size: 24,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 );
               },
             ),

--- a/lib/timers_repository.dart
+++ b/lib/timers_repository.dart
@@ -93,7 +93,7 @@ class TimersRepository with ChangeNotifier {
     }
   }
 
-  Future<void> save() async {
+  Future<void> _save() async {
     try {
       final SharedPreferences prefs = await SharedPreferences.getInstance();
       await prefs.setString(
@@ -108,19 +108,42 @@ class TimersRepository with ChangeNotifier {
 
   Future<void> addTimer(Timer timer) async {
     _timers.add(timer);
-    await save();
+    await _save();
     notifyListeners();
   }
 
   Future<void> editTimer(int index, Timer timer) async {
     _timers[index] = timer;
-    await save();
+    await _save();
     notifyListeners();
   }
 
   Future<void> deleteTimer(int index) async {
     _timers.removeAt(index);
-    await save();
+    await _save();
+    notifyListeners();
+  }
+
+  Future<void> reorder(int start, int current) async {
+    if (start < current) {
+      int end = current - 1;
+      Timer startItem = _timers[start];
+      int i = 0;
+      int local = start;
+      do {
+        _timers[local] = _timers[++local];
+        i++;
+      } while (i < end - start);
+      _timers[end] = startItem;
+    } else if (start > current) {
+      Timer startItem = _timers[start];
+      for (int i = start; i > current; i--) {
+        _timers[i] = _timers[i - 1];
+      }
+      _timers[current] = startItem;
+    }
+
+    await _save();
     notifyListeners();
   }
 }


### PR DESCRIPTION
Until now the timers were shown in the order in which they were created. Now it is also possible to sort the timers, so that they are shown in the users preferred order.

In this commit we also fixed a bug, where an error was thrown when a timer didn't had an interval. This bug occurred in the reduce function to determine the complete timer time and on the details page. When a timer doesn't contain an interval it is not possible to view the details page anymore.